### PR TITLE
Remove trailing slash in the api url

### DIFF
--- a/unit/api/base_resource.py
+++ b/unit/api/base_resource.py
@@ -6,7 +6,7 @@ from unit.models.codecs import UnitEncoder
 
 class BaseResource(object):
     def __init__(self, api_url, token):
-        self.api_url = api_url
+        self.api_url = api_url.rstrip("/")
         self.token = token
         self.headers = {
             "content-type": "application/vnd.api+json",


### PR DESCRIPTION
The [Unit docs](https://docs.unit.co/) include the trailing slash, so
the sdk should handle a base url both with the trailing slash (to be
consistent with the docs) and without it (for backwards compatability)
