### PR TITLE
Add and Remove account owners

### DIFF
--- a/e2e_tests/account_test.py
+++ b/e2e_tests/account_test.py
@@ -88,3 +88,29 @@ def test_update_account():
     response = client.accounts.update(request)
     assert response.data.type == "depositAccount"
 
+def test_get_deposit_products():
+    response = client.accounts.list()
+    for acc in response.data:
+        deposit_products = client.accounts.get_deposit_products(acc.id).data
+        for dp in deposit_products:
+            assert dp.type == "accountDepositProduct"
+
+def add_owners():
+    account_id = create_deposit_account().data.id
+    customer_ids = [create_individual_customer(), create_individual_customer()]
+    return client.accounts.add_owners(AccountOwnersRequest(account_id,
+                                                                    RelationshipArray.from_ids_array("customer",
+                                                                                                     customer_ids)))
+
+def test_add_owners():
+    response = add_owners()
+    assert response.data.type == "depositAccount"
+
+
+def test_remove_owners():
+    response = add_owners()
+    assert response.data.type == "depositAccount"
+    account_id = response.data.id
+    response = client.accounts.remove_owners(AccountOwnersRequest(account_id, response.data.relationships.customers))
+    assert response.data.type == "depositAccount"
+

--- a/e2e_tests/account_test.py
+++ b/e2e_tests/account_test.py
@@ -105,12 +105,15 @@ def add_owners():
 def test_add_owners():
     response = add_owners()
     assert response.data.type == "depositAccount"
+    assert response.data.relationships["customers"].relationships is not None
 
 
 def test_remove_owners():
     response = add_owners()
     assert response.data.type == "depositAccount"
     account_id = response.data.id
-    response = client.accounts.remove_owners(AccountOwnersRequest(account_id, response.data.relationships.customers))
+    last_owner_id = response.data.relationships["customers"].relationships.pop().id # An account should have at least one owner
+    response = client.accounts.remove_owners(AccountOwnersRequest(account_id, response.data.relationships["customers"]))
     assert response.data.type == "depositAccount"
+    assert response.data.relationships.get("customer").id == last_owner_id
 

--- a/e2e_tests/account_test.py
+++ b/e2e_tests/account_test.py
@@ -113,7 +113,7 @@ def test_remove_owners():
     response = add_owners()
     assert response.data.type == "depositAccount"
     account_id = response.data.id
-    last_owner_id = response.data.relationships["customers"].relationships.pop().id # An account should have at least one owner
+    last_owner_id = response.data.relationships["customers"].data.pop().id # An account should have at least one owner
     response = client.accounts.remove_owners(AccountOwnersRequest(account_id, response.data.relationships["customers"]))
     assert response.data.type == "depositAccount"
     assert response.data.relationships.get("customer").id == last_owner_id

--- a/e2e_tests/account_test.py
+++ b/e2e_tests/account_test.py
@@ -89,7 +89,11 @@ def test_update_account():
     assert response.data.type == "depositAccount"
 
 def test_get_deposit_products():
+    response = create_deposit_account()
+    assert response.data.type == "depositAccount"
     response = client.accounts.list()
+    assert len(response.data) > 0
+
     for acc in response.data:
         deposit_products = client.accounts.get_deposit_products(acc.id).data
         for dp in deposit_products:

--- a/e2e_tests/account_test.py
+++ b/e2e_tests/account_test.py
@@ -105,7 +105,7 @@ def add_owners():
 def test_add_owners():
     response = add_owners()
     assert response.data.type == "depositAccount"
-    assert response.data.relationships["customers"].relationships is not None
+    assert response.data.relationships["customers"].data is not None
     assert len(response.data.relationships["customers"].relationships) == 3
 
 

--- a/e2e_tests/account_test.py
+++ b/e2e_tests/account_test.py
@@ -106,7 +106,7 @@ def test_add_owners():
     response = add_owners()
     assert response.data.type == "depositAccount"
     assert response.data.relationships["customers"].data is not None
-    assert len(response.data.relationships["customers"].relationships) == 3
+    assert len(response.data.relationships["customers"].data) == 3
 
 
 def test_remove_owners():

--- a/unit/api/account_resource.py
+++ b/unit/api/account_resource.py
@@ -85,3 +85,30 @@ class AccountResource(BaseResource):
         else:
             return UnitError.from_json_api(response.json())
 
+    def get_deposit_products(self, account_id: str) -> Union[UnitResponse[List[AccountDepositProductDTO]], UnitError]:
+        response = super().get(f"{self.resource}/{account_id}/deposit-products")
+        if super().is_20x(response.status_code):
+            data = response.json().get("data")
+            return UnitResponse[List[AccountDepositProductDTO]](DtoDecoder.decode(data), None)
+        else:
+            return UnitError.from_json_api(response.json())
+
+    def add_owners(self, request: AccountOwnersRequest) -> Union[UnitResponse[AccountDTO], UnitError]:
+        payload = request.to_json_api()
+        response = super().post(f"{self.resource}/{request.account_id}/relationships/customers", payload)
+        if super().is_20x(response.status_code):
+            data = response.json().get("data")
+            return UnitResponse[AccountDTO](DtoDecoder.decode(data), None)
+        else:
+            return UnitError.from_json_api(response.json())
+
+    def remove_owners(self, request: AccountOwnersRequest) -> Union[UnitResponse[AccountDTO], UnitError]:
+        payload = request.to_json_api()
+        response = super().delete(f"{self.resource}/{request.account_id}/relationships/customers", payload)
+        if super().is_20x(response.status_code):
+            data = response.json().get("data")
+            return UnitResponse[AccountDTO](DtoDecoder.decode(data), None)
+        else:
+            return UnitError.from_json_api(response.json())
+
+

--- a/unit/api/base_resource.py
+++ b/unit/api/base_resource.py
@@ -25,8 +25,9 @@ class BaseResource(object):
         data = json.dumps(data, cls=UnitEncoder) if data is not None else None
         return requests.patch(f"{self.api_url}/{resource}", data=data, headers=self.__merge_headers(headers))
 
-    def delete(self, resource: str, params: Dict = None, headers: Optional[Dict[str, str]] = None):
-        return requests.delete(f"{self.api_url}/{resource}", params=params, headers=self.__merge_headers(headers))
+    def delete(self, resource: str, data: Dict = None, headers: Optional[Dict[str, str]] = None):
+        data = json.dumps(data, cls=UnitEncoder) if data is not None else None
+        return requests.delete(f"{self.api_url}/{resource}", data=data, headers=self.__merge_headers(headers))
 
     def put(self, resource: str, data: Optional[Dict] = None, headers: Optional[Dict[str, str]] = None):
         return requests.put(f"{self.api_url}/{resource}", data=data, headers=self.__merge_headers(headers))

--- a/unit/models/__init__.py
+++ b/unit/models/__init__.py
@@ -35,8 +35,12 @@ class RelationshipArray(Generic[T], UnitDTO):
     def __init__(self, l: List[T]):
         self.relationships = l
 
-    def to_dict(self):
+    def to_dict(self) -> Dict:
         return {"data": list(map(lambda r: r.to_dict(False), self.relationships))}
+
+    @staticmethod
+    def from_ids_array(type: str, ids: List[str]):
+        return RelationshipArray(list(map(lambda id: Relationship(type, id), ids)))
 
 
 class UnitResponse(Generic[T]):

--- a/unit/models/__init__.py
+++ b/unit/models/__init__.py
@@ -36,10 +36,10 @@ T = TypeVar('T')
 
 class RelationshipArray(Generic[T], UnitDTO):
     def __init__(self, l: List[T]):
-        self.relationships = self.__to_relationships_array(l)
+        self.data = self.__to_relationships_array(l)
 
     def to_dict(self) -> Dict:
-        return {"data": list(map(lambda r: r.to_dict(False), self.relationships))}
+        return {"data": list(map(lambda r: r.to_dict(False), self.data))}
 
     def __to_relationships_array(self, l):
         relationships = []

--- a/unit/models/__init__.py
+++ b/unit/models/__init__.py
@@ -36,20 +36,16 @@ T = TypeVar('T')
 
 class RelationshipArray(Generic[T], UnitDTO):
     def __init__(self, l: List[T]):
-        self.data = self.__to_relationships_array(l)
-
-    def to_dict(self) -> Dict:
-        return {"data": list(map(lambda r: r.to_dict(False), self.data))}
-
-    def __to_relationships_array(self, l):
         relationships = []
         for r in l:
             if isinstance(r, Relationship):
                 relationships.append(r)
             else:
                 relationships.append(Relationship(r["type"], r["id"]))
-        return relationships
+        self.data = relationships
 
+    def to_dict(self) -> Dict:
+        return {"data": list(map(lambda r: r.to_dict(False), self.data))}
 
     @staticmethod
     def from_ids_array(type: str, ids: List[str]):

--- a/unit/models/__init__.py
+++ b/unit/models/__init__.py
@@ -33,10 +33,20 @@ T = TypeVar('T')
 
 class RelationshipArray(Generic[T], UnitDTO):
     def __init__(self, l: List[T]):
-        self.relationships = l
+        self.relationships = self.__to_relationships_array(l)
 
     def to_dict(self) -> Dict:
         return {"data": list(map(lambda r: r.to_dict(False), self.relationships))}
+
+    def __to_relationships_array(self, l):
+        relationships = []
+        for r in l:
+            if isinstance(r, Relationship):
+                relationships.append(r)
+            else:
+                relationships.append(Relationship(r["type"], r["id"]))
+        return relationships
+
 
     @staticmethod
     def from_ids_array(type: str, ids: List[str]):

--- a/unit/models/account.py
+++ b/unit/models/account.py
@@ -236,3 +236,27 @@ class ListAccountParams(UnitParams):
         if self.include:
             parameters["include"] = self.include
         return parameters
+
+
+
+class AccountOwnersRequest(UnitRequest):
+    def __init__(self, account_id: str, customers: Optional[RelationshipArray] = None):
+        self.account_id = account_id
+        self.customers = customers
+
+    def to_json_api(self) -> Dict:
+        return self.customers.to_dict()
+
+    def __repr__(self):
+        json.dumps(self.to_json_api())
+
+
+class AccountDepositProductDTO(object):
+    def __init__(self, name: str):
+        self.id = id
+        self.type = "accountDepositProduct"
+        self.attributes = {"name": name}
+
+    @staticmethod
+    def from_json_api(attributes):
+        return AccountDepositProductDTO(attributes["name"])

--- a/unit/models/account.py
+++ b/unit/models/account.py
@@ -240,7 +240,7 @@ class ListAccountParams(UnitParams):
 
 
 class AccountOwnersRequest(UnitRequest):
-    def __init__(self, account_id: str, customers: Optional[RelationshipArray] = None):
+    def __init__(self, account_id: str, customers: RelationshipArray):
         self.account_id = account_id
         self.customers = customers
 
@@ -253,7 +253,6 @@ class AccountOwnersRequest(UnitRequest):
 
 class AccountDepositProductDTO(object):
     def __init__(self, name: str):
-        self.id = id
         self.type = "accountDepositProduct"
         self.attributes = {"name": name}
 

--- a/unit/models/codecs.py
+++ b/unit/models/codecs.py
@@ -276,8 +276,7 @@ def split_json_api_single_response(payload: Dict):
         relationships = dict()
         for k, v in payload.get("relationships").items():
             if isinstance(v["data"], list):
-                # todo: alex handle cases when relationships are in a form of array (e.g. jointAccount or documents)
-                continue
+                relationships[k] = RelationshipArray(v["data"])
             else:
                 relationships[k] = Relationship(v["data"]["type"], v["data"]["id"])
 

--- a/unit/models/codecs.py
+++ b/unit/models/codecs.py
@@ -4,7 +4,7 @@ from datetime import datetime, date
 from unit.utils import date_utils
 from unit.models.applicationForm import ApplicationFormDTO
 from unit.models.application import IndividualApplicationDTO, BusinessApplicationDTO, ApplicationDocumentDTO
-from unit.models.account import DepositAccountDTO, AccountLimitsDTO
+from unit.models.account import DepositAccountDTO, AccountLimitsDTO, AccountDepositProductDTO
 from unit.models.customer import IndividualCustomerDTO, BusinessCustomerDTO
 from unit.models.card import IndividualDebitCardDTO, BusinessDebitCardDTO, IndividualVirtualDebitCardDTO,\
     BusinessVirtualDebitCardDTO, PinStatusDTO, CardLimitsDTO
@@ -262,6 +262,9 @@ mappings = {
 
         "pinStatus": lambda _id, _type, attributes, relationships:
         PinStatusDTO.from_json_api(attributes),
+
+        "accountDepositProduct": lambda _id, _type, attributes, relationships:
+        AccountDepositProductDTO.from_json_api(attributes),
     }
 
 


### PR DESCRIPTION
https://github.com/unit-finance/unit-python-sdk/issues/92

Added to account resource:
- add owners
- remove owners
- get deposit products

with tests to all 3

Some changes:
- Added support to received array type relationships
- Added private function __to_relationships_array to RelationshipArray to be more typed
- Added AccountDepositProductDTO
- delete method, param changed to data

