### PR TITLE
fix: fix purchase transaction DTO creation when coordinates is not set

### DIFF
--- a/unit/models/transaction.py
+++ b/unit/models/transaction.py
@@ -152,7 +152,7 @@ class PurchaseTransactionDTO(BaseTransactionDTO):
         return PurchaseTransactionDTO(
             _id, date_utils.to_datetime(attributes["createdAt"]), attributes["direction"],
             attributes["amount"], attributes["balance"], attributes["summary"], attributes["cardLast4Digits"],
-            Merchant.from_json_api(attributes["merchant"]), Coordinates.from_json_api(attributes["coordinates"]),
+            Merchant.from_json_api(attributes["merchant"]), Coordinates.from_json_api(attributes.get("coordinates", { "latitude": None, "longitude": None })),
             attributes["recurring"], attributes.get("interchange"), attributes.get("ecommerce"),
             attributes.get("cardPresent"), attributes.get("paymentMethod"), attributes.get("digitalWallet"),
             attributes.get("cardVerificationData"), attributes.get("cardNetwork"), attributes.get("tags"),


### PR DESCRIPTION
## Summary 

Whenever Purchase Transactions do not have the `"coordinates"` attribute set, the SDK fails and raises the following error `
Merchant.from_json_api(attributes["merchant"]), Coordinates.from_json_api(attributes["coordinates"]), KeyError: 'coordinates'`

This was replicated on the Pilot environment using the customer ID `320028`

## Implementation Details

- Use `dict.get` method instad and specify a default value to be used when `coordinates` is unset.