### PR TITLE
fix: Fix tags usage in query parameters

### DIFF
--- a/unit/models/account.py
+++ b/unit/models/account.py
@@ -315,7 +315,7 @@ class CloseAccountRequest(UnitRequest):
 
 class ListAccountParams(UnitParams):
     def __init__(self, offset: int = 0, limit: int = 100, customer_id: Optional[str] = None,
-                 tags: Optional[object] = None, include: Optional[str] = None, status: Optional[AccountStatus] = None,
+                 tags: Optional[Dict[str, str]] = None, include: Optional[str] = None, status: Optional[AccountStatus] = None,
                  from_balance: Optional[int] = None, to_balance: Optional[int] = None):
         self.offset = offset
         self.limit = limit
@@ -331,7 +331,7 @@ class ListAccountParams(UnitParams):
         if self.customer_id:
             parameters["filter[customerId]"] = self.customer_id
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.include:
             parameters["include"] = self.include
         if self.status:

--- a/unit/models/application.py
+++ b/unit/models/application.py
@@ -228,7 +228,7 @@ class UploadDocumentRequest(object):
 
 class ListApplicationParams(UnitParams):
     def __init__(self, offset: int = 0, limit: int = 100, email: Optional[str] = None,
-                 tags: Optional[object] = None, query: Optional[str] = None,
+                 tags: Optional[Dict[str, str]] = None, query: Optional[str] = None,
                  sort: Optional[Literal["createdAt", "-createdAt"]] = None):
         self.offset = offset
         self.limit = limit
@@ -244,7 +244,7 @@ class ListApplicationParams(UnitParams):
         if self.query:
             parameters["filter[query]"] = self.query
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.sort:
             parameters["sort"] = self.sort
         return parameters

--- a/unit/models/applicationForm.py
+++ b/unit/models/applicationForm.py
@@ -106,7 +106,7 @@ class CreateApplicationFormRequest(UnitRequest):
 
 
 class ListApplicationFormParams(UnitParams):
-    def __init__(self, offset: int = 0, limit: int = 100, tags: Optional[object] = None,
+    def __init__(self, offset: int = 0, limit: int = 100, tags: Optional[Dict[str, str]] = None,
                  sort: Optional[Literal["createdAt", "-createdAt"]] = None):
         self.offset = offset
         self.limit = limit
@@ -116,7 +116,7 @@ class ListApplicationFormParams(UnitParams):
     def to_dict(self) -> Dict:
         parameters = {"page[limit]": self.limit, "page[offset]": self.offset}
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.sort:
             parameters["sort"] = self.sort
         return parameters

--- a/unit/models/card.py
+++ b/unit/models/card.py
@@ -572,7 +572,7 @@ class CardLimitsDTO(object):
 
 class ListCardParams(UnitParams):
     def __init__(self, offset: int = 0, limit: int = 100, account_id: Optional[str] = None,
-                 customer_id: Optional[str] = None, tags: Optional[object] = None, include: Optional[str] = None,
+                 customer_id: Optional[str] = None, tags: Optional[Dict[str, str]] = None, include: Optional[str] = None,
                  sort: Optional[Literal["createdAt", "-createdAt"]] = None,
                  status: Optional[List[CardStatus]] = None):
         self.offset = offset
@@ -591,7 +591,7 @@ class ListCardParams(UnitParams):
         if self.account_id:
             parameters["filter[accountId]"] = self.account_id
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.include:
             parameters["include"] = self.include
         if self.sort:

--- a/unit/models/check_deposit.py
+++ b/unit/models/check_deposit.py
@@ -60,7 +60,7 @@ class CreateCheckDepositRequest(UnitRequest):
 
 class ListCheckDepositParams(UnitParams):
     def __init__(self, offset: int = 0, limit: int = 100, account_id: Optional[str] = None,
-                 customer_id: Optional[str] = None, tags: Optional[object] = None,
+                 customer_id: Optional[str] = None, tags: Optional[Dict[str, str]] = None,
                  sort: Optional[str] = None, include: Optional[str] = None):
         self.offset = offset
         self.limit = limit
@@ -77,7 +77,7 @@ class ListCheckDepositParams(UnitParams):
         if self.customer_id:
             parameters["filter[customerId]"] = self.customer_id
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.sort:
             parameters["sort"] = self.sort
         if self.include:

--- a/unit/models/counterparty.py
+++ b/unit/models/counterparty.py
@@ -156,7 +156,7 @@ class CounterpartyBalanceDTO(object):
 
 class ListCounterpartyParams(UnitParams):
     def __init__(self, offset: int = 0, limit: int = 100, customer_id: Optional[str] = None,
-                 tags: Optional[object] = None):
+                 tags: Optional[Dict[str, str]] = None):
         self.offset = offset
         self.limit = limit
         self.customer_id = customer_id
@@ -167,6 +167,6 @@ class ListCounterpartyParams(UnitParams):
         if self.customer_id:
             parameters["filter[customerId]"] = self.customer_id
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         return parameters
 

--- a/unit/models/customer.py
+++ b/unit/models/customer.py
@@ -155,7 +155,7 @@ PatchCustomerRequest = Union[PatchIndividualCustomerRequest, PatchBusinessCustom
 
 class ListCustomerParams(UnitParams):
     def __init__(self, offset: int = 0, limit: int = 100, query: Optional[str] = None, email: Optional[str] = None,
-                 tags: Optional[object] = None, sort: Optional[Literal["createdAt", "-createdAt"]] = None):
+                 tags: Optional[Dict[str, str]] = None, sort: Optional[Literal["createdAt", "-createdAt"]] = None):
         self.offset = offset
         self.limit = limit
         self.query = query
@@ -170,7 +170,7 @@ class ListCustomerParams(UnitParams):
         if self.email:
             parameters["filter[email]"] = self.email
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.sort:
             parameters["sort"] = self.sort
         return parameters

--- a/unit/models/payment.py
+++ b/unit/models/payment.py
@@ -290,7 +290,7 @@ PatchPaymentRequest = Union[PatchAchPaymentRequest, PatchBookPaymentRequest]
 
 class ListPaymentParams(UnitParams):
     def __init__(self, limit: int = 100, offset: int = 0, account_id: Optional[str] = None,
-                 customer_id: Optional[str] = None, tags: Optional[object] = None,
+                 customer_id: Optional[str] = None, tags: Optional[Dict[str, str]] = None,
                  status: Optional[List[PaymentStatus]] = None, type: Optional[List[PaymentTypes]] = None,
                  direction: Optional[List[PaymentDirections]] = None, since: Optional[str] = None,
                  until: Optional[str] = None, sort: Optional[Literal["createdAt", "-createdAt"]] = None,
@@ -315,7 +315,7 @@ class ListPaymentParams(UnitParams):
         if self.account_id:
             parameters["filter[accountId]"] = self.account_id
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.status:
             for idx, status_filter in enumerate(self.status):
                 parameters[f"filter[status][{idx}]"] = status_filter

--- a/unit/models/received_payment.py
+++ b/unit/models/received_payment.py
@@ -53,7 +53,7 @@ class PatchReceivedPaymentRequest(object):
 
 class ListReceivedPaymentParams(UnitParams):
     def __init__(self, limit: int = 100, offset: int = 0, account_id: Optional[str] = None,
-                 customer_id: Optional[str] = None, tags: Optional[object] = None,
+                 customer_id: Optional[str] = None, tags: Optional[Dict[str, str]] = None,
                  status: Optional[List[AchReceivedPaymentStatus]] = None, include_completed: Optional[bool] = None,
                  sort: Optional[Literal["createdAt", "-createdAt"]] = None, include: Optional[str] = None):
         self.limit = limit
@@ -73,7 +73,7 @@ class ListReceivedPaymentParams(UnitParams):
         if self.account_id:
             parameters["filter[accountId]"] = self.account_id
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.include_completed:
             parameters["filter[includeCompleted]"] = self.include_completed
         if self.status:

--- a/unit/models/reward.py
+++ b/unit/models/reward.py
@@ -96,7 +96,7 @@ class ListRewardsParams(UnitParams):
         until: Optional[datetime] = None,
         sort: Optional[SORT_ORDERS] = None,
         include: Optional[List[RELATED_RESOURCES]] = None,
-        tags: Optional[object] = None,
+        tags: Optional[Dict[str, str]] = None,
     ):
         self.limit = limit
         self.offset = offset
@@ -143,7 +143,7 @@ class ListRewardsParams(UnitParams):
             parameters["sort"] = self.sort
 
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
 
         return parameters
 

--- a/unit/models/transaction.py
+++ b/unit/models/transaction.py
@@ -465,7 +465,7 @@ class PatchTransactionRequest(BaseTransactionDTO, UnitRequest):
 
 class ListTransactionParams(UnitParams):
     def __init__(self, limit: int = 100, offset: int = 0, account_id: Optional[str] = None,
-                 customer_id: Optional[str] = None, query: Optional[str] = None, tags: Optional[object] = None,
+                 customer_id: Optional[str] = None, query: Optional[str] = None, tags: Optional[Dict[str, str]] = None,
                  since: Optional[str] = None, until: Optional[str] = None, card_id: Optional[str] = None,
                  type: Optional[List[str]] = None, exclude_fees: Optional[bool] = None,
                  sort: Optional[Literal["createdAt", "-createdAt"]] = None, include: Optional[str] = None):
@@ -492,7 +492,7 @@ class ListTransactionParams(UnitParams):
         if self.query:
             parameters["filter[query]"] = self.query
         if self.tags:
-            parameters["filter[tags]"] = self.tags
+            parameters["filter[tags]"] = json.dumps(self.tags)
         if self.since:
             parameters["filter[since]"] = self.since
         if self.until:


### PR DESCRIPTION
Ensure the `Dict[str, str]` typing as well as a `json.dumps` of the tags when filtering.

According to the [docs](https://docs.unit.co/#tag-constaints) the `tags` are limited to `key-value` pairs of strings, so the `Optional[object]` feels like a rather broad typing for the matter.
I was also running into issues where the filter in the query parameters was expecting a "valid json":
![image](https://user-images.githubusercontent.com/8291177/208560660-e5078567-7271-4aa9-a022-f0572407f1b1.png)
Dumping the tags dict into a JSON string seems to do the trick:
![image](https://user-images.githubusercontent.com/8291177/208560825-44b6fecc-ad96-47dd-9e33-806b8185c1f6.png)

This isn't an issue with the request objects because of the `json.dumps` already being called on the data before the Unit requests go through.
