### PR TITLE
UnitErrorPayload __str__

### DIFF
--- a/unit/models/__init__.py
+++ b/unit/models/__init__.py
@@ -96,7 +96,7 @@ class UnitErrorPayload(object):
         self.meta = meta
 
     def __str__(self):
-        return self.detail
+        return self.detail or self.title
 
 
 class UnitError(object):


### PR DESCRIPTION
error should be printed as detail or title
https://github.com/unit-finance/unit-python-sdk/issues/189

An "error object" MUST contain a title and the HTTP status code.
https://developers.unit.co/about-jsonapi/#intro-errors