### PR TITLE
fix: account status values

### DIFF
--- a/unit/models/account.py
+++ b/unit/models/account.py
@@ -1,7 +1,7 @@
 from unit.utils import date_utils
 from unit.models import *
 
-AccountStatus = Literal["Open", "Closed"]
+AccountStatus = Literal["Open", "Frozen", "Closed"]
 CloseReason = Literal["ByCustomer", "Fraud"]
 FraudReason = Literal["ACHActivity", "CardActivity", "CheckActivity", "ApplicationHistory", "AccountActivity",
                       "ClientIdentified", "IdentityTheft", "LinkedToFraudulentCustomer"]


### PR DESCRIPTION
Add the missing `Frozen` account status from the API docs: https://docs.unit.co/resources#attributes-9

Closes unit-finance/unit-python-sdk#224
