### PR TITLE
fix typo error for pathBusinessVirtualCard

### DIFF
--- a/unit/models/card.py
+++ b/unit/models/card.py
@@ -335,7 +335,7 @@ class PatchBusinessVirtualCard(UnitRequest):
         self.limits = limits
 
     def to_json_api(self, _type: str = "businessVirtualDebitCard") -> Dict:
-        return super().to_payload(_type, igonre=["card_id"])
+        return super().to_payload(_type, ignore=["card_id"])
 
 
 class PatchBusinessVirtualDebitCard(PatchBusinessVirtualCard):


### PR DESCRIPTION
Problem Description - 

Case ID - https://unitfinance.zendesk.com/agent/tickets/94183

unit-python-sdk - version = 1.0.1

```
[unit_client.py:3573] - Traceback (most recent call last):
 File "/workspace/common/unit/unit_client.py", line 3559, in update_business_virtual_credit_card
 response = self.unit.cards.update(request)
 File "/layers/google.python.pip/pip/lib/python3.9/site-packages/unit/api/card_resource.py", line 71, in update
 payload = request.to_json_api()
 File "/layers/google.python.pip/pip/lib/python3.9/site-packages/unit/models/card.py", line 347, in to_json_api
 return super().to_json_api("businessVirtualCreditCard")
 File "/layers/google.python.pip/pip/lib/python3.9/site-packages/unit/models/card.py", line 338, in to_json_api
 return super().to_payload(_type, igonre=["card_id"])
TypeError: to_payload() got an unexpected keyword argument 'igonre'
```