### PR TITLE
feat: Use Unit timeout value on request's timeout

### DIFF
--- a/unit/api/base_resource.py
+++ b/unit/api/base_resource.py
@@ -49,7 +49,7 @@ class BaseResource(object):
                               max_time=self.configuration.get_timeout,
                               jitter=backoff.random_jitter)
         def get_with_backoff(path: str, p: Dict, h: Dict[str, str]):
-            return requests.get(path, params=p, headers=h)
+            return requests.get(path, params=p, headers=h, timeout=self.configuration.get_timeout())
 
         return get_with_backoff(f"{self.configuration.api_url}/{resource}", params, self.__merge_headers(headers))
 
@@ -62,7 +62,7 @@ class BaseResource(object):
                               max_time=self.configuration.get_timeout,
                               jitter=backoff.random_jitter)
         def post_with_backoff(path: str, d: Dict, h: Dict[str, str]):
-            return requests.post(path, data=d, headers=h)
+            return requests.post(path, data=d, headers=h, timeout=self.configuration.get_timeout())
 
         return post_with_backoff(f"{self.configuration.api_url}/{resource}", data, self.__merge_headers(headers))
 
@@ -75,7 +75,7 @@ class BaseResource(object):
                               max_time=self.configuration.get_timeout,
                               jitter=backoff.random_jitter)
         def post_create_with_backoff(path: str, d, h):
-            return requests.post(path, data=d, headers=h)
+            return requests.post(path, data=d, headers=h, timeout=self.configuration.get_timeout())
 
         return post_create_with_backoff(f"{self.configuration.api_url}/{resource}", data, self.__merge_headers(headers))
 
@@ -88,7 +88,7 @@ class BaseResource(object):
                               max_time=self.configuration.get_timeout,
                               jitter=backoff.random_jitter)
         def post_full_path_with_backoff(p, d, h):
-            return requests.post(p, data=d, headers=h)
+            return requests.post(p, data=d, headers=h, timeout=self.configuration.get_timeout())
 
         return post_full_path_with_backoff(path, data, self.__merge_headers(headers))
 
@@ -101,7 +101,7 @@ class BaseResource(object):
                               max_time=self.configuration.get_timeout,
                               jitter=backoff.random_jitter)
         def patch_with_backoff(p, d, h):
-            return requests.patch(p, data=d, headers=h)
+            return requests.patch(p, data=d, headers=h, timeout=self.configuration.get_timeout())
 
         return patch_with_backoff(f"{self.configuration.api_url}/{resource}", data, self.__merge_headers(headers))
 
@@ -114,7 +114,7 @@ class BaseResource(object):
                               max_time=self.configuration.get_timeout,
                               jitter=backoff.random_jitter)
         def delete_with_backoff(p, d, h):
-            return requests.delete(p, data=d, headers=h)
+            return requests.delete(p, data=d, headers=h, timeout=self.configuration.get_timeout())
 
         return delete_with_backoff(f"{self.configuration.api_url}/{resource}", data, self.__merge_headers(headers))
 
@@ -125,7 +125,7 @@ class BaseResource(object):
                               max_time=self.configuration.get_timeout,
                               jitter=backoff.random_jitter)
         def put_with_backoff(p, d, h):
-            return requests.put(p, data=d, headers=h)
+            return requests.put(p, data=d, headers=h, timeout=self.configuration.get_timeout())
 
         return put_with_backoff(f"{self.configuration.api_url}/{resource}", data, self.__merge_headers(headers))
 


### PR DESCRIPTION
Hey, team!

We've had some issues in the past that we linked to outage/instability on the Unit API's side - we saw on a couple occasions our async workers getting "locked", we looked into what was happening and, basically, during these API outage/unstable periods, our API requests were simply hanging without ever failing due to timeouts. ([Link to Zendesk ID](https://unitfinance.zendesk.com/agent/tickets/71988))

This does check out, the `Configuration` object has a `timeout` parameter, but that is only used on the `backoff.on_predicate(max_time)`, and the predicate truly only applies to "proper" responses received from the server, so if a request takes forever, this `max_time` won't ever be used.

The `requests` lib does not have a default timeout ([seen here](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts)), and I believe it's best practice to have this set - to avoid having requests hanging.

The implementation here is simply passing in `timeout=self.configuration.get_timeout()` to the requests on the `BaseResource`. The caveat: the timeout will now raise a `requests.Exception.ConnectTimeout/ReadTimeout`, and I'm not sure if y'all want to handle this actively, or if it's fair game to just let this exception bubble up.